### PR TITLE
feat: 노래 생성 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
-node_modules
-/env
+# compiled output
 /dist
+/node_modules
+
+# OS
+.DS_Store
+
+# env
+/env

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 /env
+/dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,12 @@
         "@nestjs/config": "^3.2.3",
         "@nestjs/core": "^10.0.0",
         "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/swagger": "^7.4.0",
         "@nestjs/typeorm": "^10.0.2",
         "pg": "^8.12.0",
         "reflect-metadata": "^0.2.0",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.0.0",
@@ -1662,6 +1664,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
+      "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
+      "license": "MIT"
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.5.tgz",
@@ -1804,6 +1812,26 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.1.tgz",
@@ -1848,6 +1876,39 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.0.tgz",
+      "integrity": "sha512-dCiwKkRxcR7dZs5jtrGspBAe/nqJd1AYzOBTzw9iCdbq3BGrLpwokelk6lFZPe4twpTsPQqzNKBwKzVbI6AR/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "^0.15.0",
+        "@nestjs/mapped-types": "2.0.5",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0",
+        "swagger-ui-dist": "5.17.14"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.0.0 || ^7.0.0",
+        "@nestjs/common": "^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "10.4.1",
@@ -2901,7 +2962,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -6443,7 +6503,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8566,6 +8625,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.17.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+      "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/axios": "^3.0.3",
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.2.3",
         "@nestjs/core": "^10.0.0",
@@ -1670,6 +1671,17 @@
       "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
       "license": "MIT"
     },
+    "node_modules/@nestjs/axios": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-3.0.3.tgz",
+      "integrity": "sha512-h6TCn3yJwD6OKqqqfmtRS5Zo4E46Ip2n+gK1sqwzNBC+qxQ9xpCu+ODVRFur6V3alHSCSBxb3nNtt73VEdluyA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "axios": "^1.3.1",
+        "rxjs": "^6.0.0 || ^7.0.0"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.4.5.tgz",
@@ -2995,8 +3007,19 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -3723,7 +3746,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -4026,7 +4048,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -4910,6 +4931,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.8.tgz",
+      "integrity": "sha512-xgrmBhBToVKay1q2Tao5LI26B83UhrB/vM1avwVSDzt8rx3rO6AizBAaF46EgksTVr+rFTQaqZZ9MVBfUe4nig==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
@@ -4983,7 +5025,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7698,6 +7739,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@nestjs/axios": "^3.0.3",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.3",
     "@nestjs/core": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "@nestjs/config": "^3.2.3",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/swagger": "^7.4.0",
     "@nestjs/typeorm": "^10.0.2",
     "pg": "^8.12.0",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { SongsModule } from './songs/songs.module';
 
 @Module({
   imports: [
@@ -35,6 +36,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
         };
       },
     }),
+    SongsModule,
   ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Songs } from './entities/songs.entity';
-import { Users } from './entities/users.entity';
-import { Posts } from './entities/posts.entity';
 
 @Module({
   imports: [
@@ -33,12 +30,11 @@ import { Posts } from './entities/posts.entity';
           ssl: {
             rejectUnauthorized: false, // SSL 인증서를 검증하지 않도록 설정 (보안상 주의)
           },
-          entities: [Songs, Users, Posts],
+          entities: [__dirname + '/**/*.entity{.ts,.js}'],
           synchronize: true,
         };
       },
     }),
-    TypeOrmModule.forFeature([Songs, Users, Posts]),
   ],
 })
 export class AppModule {}

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,18 +1,7 @@
-import { Injectable, OnModuleInit } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
+import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class AppService implements OnModuleInit {
-  constructor(private configService: ConfigService) {}
-
-  onModuleInit() {
-    console.log('DB_HOST:', this.configService.get('DB_HOST'));
-    console.log('DB_PORT:', this.configService.get('DB_PORT'));
-    console.log('DB_USER:', this.configService.get('DB_USER'));
-    console.log('DB_PASSWORD:', this.configService.get('DB_PASSWORD'));
-    console.log('DB_NAME:', this.configService.get('DB_NAME'));
-  }
-
+export class AppService {
   getHello(): string {
     return 'Hello World!';
   }

--- a/src/entities/songs.entity.ts
+++ b/src/entities/songs.entity.ts
@@ -9,5 +9,14 @@ export class Songs {
     title: string;
 
     @Column()
+    keywords: string;
+
+    @Column()
+    style: string;
+
+    @Column()
     link: string;
+
+    @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+    created_at: Date;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,20 @@
 import { NestFactory } from '@nestjs/core';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const config = new DocumentBuilder()
+    .setTitle('NestJS API')
+    .setDescription('NestJS API description')
+    .setVersion('1.0')
+    .addTag('nestjs')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+  
   await app.listen(3000);
 }
 bootstrap();

--- a/src/songs/dtos/create-song.dto.ts
+++ b/src/songs/dtos/create-song.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class CreateSongDto {
+    @ApiProperty({ description: '노래 생성을 위한 키워드' })
+    keywords: string;
+  
+    @ApiProperty({ description: '노래의 스타일' })
+    style: string;
+  
+    @ApiProperty({ description: '노래의 제목' })
+    title: string;
+}

--- a/src/songs/dtos/song-response.dto.ts
+++ b/src/songs/dtos/song-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class SongResponseDto {
+    @ApiProperty({ description: '생성된 노래의 ID' })
+    song_id: number;
+  
+    @ApiProperty({ description: 'S3 저장소의 노래 파일 접근 링크' })
+    link: string;
+}

--- a/src/songs/songs.controller.ts
+++ b/src/songs/songs.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Post, Body } from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiResponse } from "@nestjs/swagger";
+import { SongsService } from "./songs.service";
+import { CreateSongDto } from "./dtos/create-song.dto";
+import { SongResponseDto } from "./dtos/song-response.dto";
+import e from "express";
+
+@ApiTags('songs')
+@Controller('songs')
+export class SongsController {
+    constructor(private readonly songsService: SongsService) {}
+
+    @Post()
+    @ApiOperation({ summary: 'AI 노래 생성 API' })
+    @ApiResponse({ status: 201, description: '노래 생성 성공', type: SongResponseDto })
+    async createSong(@Body() createSongDto: CreateSongDto): Promise<SongResponseDto> {
+        return this.songsService.createSong(createSongDto);
+    }
+}

--- a/src/songs/songs.module.ts
+++ b/src/songs/songs.module.ts
@@ -1,0 +1,14 @@
+// src/songs/songs.module.ts
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HttpModule } from '@nestjs/axios';
+import { SongsController } from './songs.controller';
+import { SongsService } from './songs.service';
+import { Songs } from '../entities/songs.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Songs]), HttpModule],
+  controllers: [SongsController],
+  providers: [SongsService],
+})
+export class SongsModule {}

--- a/src/songs/songs.service.spec.ts
+++ b/src/songs/songs.service.spec.ts
@@ -1,0 +1,101 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { Repository } from 'typeorm';
+import { of } from 'rxjs';
+import { SongsService } from './songs.service';
+import { Songs } from '../entities/songs.entity';
+import { CreateSongDto } from './dtos/create-song.dto';
+
+describe('SongsService', () => {
+  let service: SongsService;
+  let mockSongsRepository: Partial<Repository<Songs>>;
+  let mockHttpService: Partial<HttpService>;
+  let mockConfigService: Partial<ConfigService> & { get: jest.Mock };
+
+  beforeEach(async () => {
+    mockSongsRepository = {
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+
+    mockHttpService = {
+      post: jest.fn(),
+    };
+
+    mockConfigService = {
+      get: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SongsService,
+        {
+          provide: getRepositoryToken(Songs),
+          useValue: mockSongsRepository,
+        },
+        {
+          provide: HttpService,
+          useValue: mockHttpService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<SongsService>(SongsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('createSong', () => {
+    it('should create a song and return song_id and link', async () => {
+      const createSongDto: CreateSongDto = {
+        keywords: 'test keywords',
+        style: 'test style',
+        title: 'test title',
+      };
+
+      const mockAiServerUrl = 'http://mock-ai-server.com';
+      const mockS3Link = 'http://mock-s3-link.com';
+      const mockSavedSong = { id: 1, link: mockS3Link, ...createSongDto };
+
+      mockConfigService.get.mockReturnValue(mockAiServerUrl);
+      (mockHttpService.post as jest.Mock).mockReturnValue(of({ data: { link: mockS3Link } }));
+      mockSongsRepository.create = jest.fn().mockReturnValue(mockSavedSong);
+      mockSongsRepository.save = jest.fn().mockResolvedValue(mockSavedSong);
+
+      const result = await service.createSong(createSongDto);
+
+      expect(mockConfigService.get).toHaveBeenCalledWith('AI_SERVER_URL');
+      expect(mockHttpService.post).toHaveBeenCalledWith(mockAiServerUrl, createSongDto);
+      expect(mockSongsRepository.create).toHaveBeenCalledWith({
+        ...createSongDto,
+        link: mockS3Link,
+      });
+      expect(mockSongsRepository.save).toHaveBeenCalledWith(mockSavedSong);
+      expect(result).toEqual({
+        song_id: mockSavedSong.id,
+        link: mockSavedSong.link,
+      });
+    });
+
+    it('should throw an error if AI server request fails', async () => {
+      const createSongDto: CreateSongDto = {
+        keywords: 'test keywords',
+        style: 'test style',
+        title: 'test title',
+      };
+
+      mockConfigService.get.mockReturnValue('http://mock-ai-server.com');
+      (mockHttpService.post as jest.Mock).mockImplementation(() => of({ data: {} }));
+
+      await expect(service.createSong(createSongDto)).rejects.toThrow();
+    });
+  });
+});

--- a/src/songs/songs.service.ts
+++ b/src/songs/songs.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+import { Repository } from 'typeorm';
+import { CreateSongDto } from './dtos/create-song.dto';
+import { SongResponseDto } from './dtos/song-response.dto';
+import { Songs } from '../entities/songs.entity';
+
+@Injectable()
+export class SongsService {
+    constructor(
+        @InjectRepository(Songs)
+        private songsRepository: Repository<Songs>,
+        private httpService: HttpService,
+        private configService: ConfigService,
+    ) {}
+
+    async createSong(createSongDto: CreateSongDto): Promise<SongResponseDto> {
+        const aiServerUrl = this.configService.get<string>('AI_SERVER_URL');
+
+        const aiResponse = await firstValueFrom(
+            this.httpService.post(aiServerUrl, createSongDto)
+        );
+
+        const s3Link = aiResponse.data.link;
+        const song = this.songsRepository.create({ 
+            ...createSongDto,
+            link: s3Link,
+        });
+        const savedSong = await this.songsRepository.save(song);
+
+        return {
+            song_id: savedSong.id,
+            link: savedSong.link,
+        };
+    }
+}


### PR DESCRIPTION
# 💡 Issue Number

- #2 

# 🔎 Key Changes
- frontend에서 보낸 노래 키워드, 스타일, 제목을 AI 서버에 보내주는 기능
- AI서버에서 생성된 노래를 저장한 s3Link를 DB에 저장하는 기능
- 저장된 노래 정보를 frontend에 보내주는 기능

# 💌 To Reviewers
- 주의사항
